### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ bin/
 gen/
 out/
 build/
-\gradle/.*
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
http://stackoverflow.com/questions/27361337/the-project-is-using-an-unsupported-version-of-gradle

ignoring gradle file will leave the cloner with no default gradle.wrapper which will not tell the android studio which gradle version to use  
which will end up pointing to false gradle version (unsupported)